### PR TITLE
Issue/11 update xiao ble symbol and footprint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "pcb_data/kicad_library/external/OPL_Kicad_Library"]
 	path = pcb_data/kicad_library/external/OPL_Kicad_Library
-	url = https://github.com/Seeed-Studio/OPL_Kicad_Library.git
+	url = https://github.com/kim-xps12/OPL_Kicad_Library.git
 [submodule "pcb_data/kicad_library/external/KiCAD_FootPrint"]
 	path = pcb_data/kicad_library/external/KiCAD_FootPrint
-	url = https://github.com/Salicylic-acid3/KiCAD_FootPrint.git
+	url = https://github.com/kim-xps12/KiCAD_FootPrint.git
+[submodule "pcb_data/kicad_library/external/kleeb"]
+	path = pcb_data/kicad_library/external/kleeb
+	url = https://github.com/kim-xps12/kleeb.git

--- a/pcb_data/Assemble_L/Assemble_L.kicad_sch
+++ b/pcb_data/Assemble_L/Assemble_L.kicad_sch
@@ -5,6 +5,148 @@
 	(uuid "e3283b87-c43c-4022-8f4a-8d39acdeb3e4")
 	(paper "A4")
 	(lib_symbols
+		(symbol "Connector_Generic:Conn_01x02"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x02"
+				(at 0 -5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x02_1_1"
+				(rectangle
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Diode:1N4148"
 			(pin_numbers
 				(hide yes)
@@ -273,609 +415,6 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Seeed_Studio_XIAO_Series:XIAO-nRF52840-DIP"
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "U"
-				(at -3.048 1.778 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "XIAO-nRF52840-DIP"
-				(at 3.048 -0.254 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" "Module:MOUDLE14P-XIAO-DIP-SMD"
-				(at 12.7 -30.734 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" ""
-				(at -3.81 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" ""
-				(at -3.81 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "XIAO-nRF52840-DIP_1_0"
-				(polyline
-					(pts
-						(xy -3.81 -1.27) (xy 39.37 -1.27)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -3.81) (xy -5.08 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -3.81) (xy -3.81 -1.27)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -7.62) (xy -5.08 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -7.62) (xy -3.81 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -11.43) (xy -5.08 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -11.43) (xy -3.81 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -15.24) (xy -5.08 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -15.24) (xy -3.81 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -19.05) (xy -5.08 -19.05)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -22.86) (xy -5.08 -22.86)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -26.67) (xy -5.08 -26.67)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -29.21) (xy -3.81 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -1.27) (xy 39.37 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -3.81) (xy 39.37 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -7.62) (xy 39.37 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -11.43) (xy 39.37 -29.21)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -29.21) (xy -3.81 -29.21)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -3.81) (xy 39.37 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -7.62) (xy 39.37 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -11.43) (xy 39.37 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -15.24) (xy 39.37 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -19.05) (xy 39.37 -19.05)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -22.86) (xy 39.37 -22.86)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -26.67) (xy 39.37 -26.67)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(pin passive line
-					(at -6.35 -3.81 0)
-					(length 2.54)
-					(name "P0.02_AIN0_LOW_A0_D0"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -7.62 0)
-					(length 2.54)
-					(name "P0.03_AIN1_LOW_A1_D1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -11.43 0)
-					(length 2.54)
-					(name "P0.28_AIN4_LOW_A2_D2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -15.24 0)
-					(length 2.54)
-					(name "P0.29_AIN5_LOW_A3_D3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -19.05 0)
-					(length 2.54)
-					(name "P0.04_AIN2_A4_D4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -22.86 0)
-					(length 2.54)
-					(name "P0.05_AIN3_A5_D5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -26.67 0)
-					(length 2.54)
-					(name "P1.11_TX_D6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -3.81 180)
-					(length 2.54)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -7.62 180)
-					(length 2.54)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "13"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -11.43 180)
-					(length 2.54)
-					(name "3V3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -15.24 180)
-					(length 2.54)
-					(name "P1.15_MOSI_D10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -19.05 180)
-					(length 2.54)
-					(name "P1.14_MISO_D9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -22.86 180)
-					(length 2.54)
-					(name "P1.13_SCK_D8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -26.67 180)
-					(length 2.54)
-					(name "P1.12_RX_D7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "Switch:SW_Push"
 			(pin_numbers
 				(hide yes)
@@ -1016,6 +555,469 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "mcu:xiao-ble"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at -17.78 16.51 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "xiao-ble"
+				(at -15.24 13.97 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -7.62 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at -7.62 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "xiao-ble_0_1"
+				(rectangle
+					(start -19.05 12.7)
+					(end 19.05 -13.97)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "xiao-ble_1_1"
+				(pin bidirectional line
+					(at -21.59 7.62 0)
+					(length 2.54)
+					(name "A2/0.02_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 5.08 0)
+					(length 2.54)
+					(name "A4/0.03_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 2.54 0)
+					(length 2.54)
+					(name "A10/0.28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 0 0)
+					(length 2.54)
+					(name "A11/0.29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -2.54 0)
+					(length 2.54)
+					(name "A8_SDA/0.04_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -5.08 0)
+					(length 2.54)
+					(name "A9_SCL/0.05_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -7.62 0)
+					(length 2.54)
+					(name "B8_TX/1.11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -6.35 -16.51 90)
+					(length 2.54)
+					(name "BAT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -3.81 15.24 270)
+					(length 2.54)
+					(name "A31_SWDIO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -3.81 -16.51 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -1.27 15.24 270)
+					(length 2.54)
+					(name "A30_SWCLK"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -1.27 -16.51 90)
+					(length 2.54)
+					(name "NFC1/0.09_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 1.27 15.24 270)
+					(length 2.54)
+					(name "RESET"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 1.27 -16.51 90)
+					(length 2.54)
+					(name "NFC2/0.10_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 3.81 15.24 270)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 21.59 7.62 180)
+					(length 2.54)
+					(name "5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 21.59 5.08 180)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 21.59 2.54 180)
+					(length 2.54)
+					(name "3V3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 0 180)
+					(length 2.54)
+					(name "A6_MOSI/1.15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -2.54 180)
+					(length 2.54)
+					(name "A5_MISO/1.14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -5.08 180)
+					(length 2.54)
+					(name "A7_SCK/1.13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -7.62 180)
+					(length 2.54)
+					(name "B9_RX/1.12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1578,6 +1580,12 @@
 		(uuid "e7c7797a-29fa-4d5d-b072-0d55172149e7")
 	)
 	(junction
+		(at 261.62 58.42)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ed9c4935-2814-4bf2-8775-8142156fe90c")
+	)
+	(junction
 		(at 135.89 104.14)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1626,24 +1634,54 @@
 		(uuid "fecf7f82-c546-4c93-bafa-1dd386b9edf0")
 	)
 	(no_connect
-		(at 261.62 64.77)
+		(at 256.54 63.5)
 		(uuid "084212be-3c5a-4b5d-8954-1d2380b1c7a4")
 	)
 	(no_connect
-		(at 261.62 68.58)
+		(at 236.22 80.01)
+		(uuid "11652b87-1f40-4c27-855b-13281f502347")
+	)
+	(no_connect
+		(at 233.68 48.26)
+		(uuid "25309ae1-8a0e-43f7-8252-5ee795b35b7a")
+	)
+	(no_connect
+		(at 256.54 66.04)
 		(uuid "377834fb-9171-4e01-8299-8a0a8e1a72c3")
 	)
 	(no_connect
-		(at 261.62 53.34)
+		(at 233.68 80.01)
+		(uuid "48f555cc-120a-48b2-bfda-79fac139c087")
+	)
+	(no_connect
+		(at 236.22 48.26)
+		(uuid "691f03a5-179b-4742-9760-f14d287e6761")
+	)
+	(no_connect
+		(at 256.54 55.88)
 		(uuid "72711a93-52ab-4d28-a53b-18ce33eaf033")
 	)
 	(no_connect
-		(at 261.62 60.96)
+		(at 256.54 60.96)
 		(uuid "7f6b0223-cf51-45f3-822c-207c5b29ebc8")
 	)
 	(no_connect
-		(at 261.62 72.39)
+		(at 231.14 48.26)
+		(uuid "a3159b2a-7bc7-4f89-ab3d-11cc7affe810")
+	)
+	(no_connect
+		(at 256.54 68.58)
 		(uuid "b212ae73-14a9-42c0-9f6e-2d3849ecba41")
+	)
+	(wire
+		(pts
+			(xy 209.55 55.88) (xy 209.55 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "006e347d-673a-4da1-b6ff-7fc5b65b229b")
 	)
 	(wire
 		(pts
@@ -1657,7 +1695,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 60.96) (xy 213.36 60.96)
+			(xy 203.2 59.69) (xy 207.01 59.69)
 		)
 		(stroke
 			(width 0)
@@ -1727,6 +1765,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 66.04) (xy 207.01 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17bd1e0e-4bfa-4cf0-8364-c2c7bda83b7c")
+	)
+	(wire
+		(pts
 			(xy 95.25 104.14) (xy 95.25 124.46)
 		)
 		(stroke
@@ -1734,6 +1782,16 @@
 			(type default)
 		)
 		(uuid "18e42cba-0f76-4f4a-ad73-634c21044202")
+	)
+	(wire
+		(pts
+			(xy 261.62 48.26) (xy 261.62 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1b0d9cdf-dcb4-438c-9105-cb00ab4f8326")
 	)
 	(wire
 		(pts
@@ -1757,6 +1815,16 @@
 	)
 	(wire
 		(pts
+			(xy 238.76 48.26) (xy 261.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "20839323-2318-462d-a3d0-fcd7ece2d5db")
+	)
+	(wire
+		(pts
 			(xy 135.89 63.5) (xy 135.89 83.82)
 		)
 		(stroke
@@ -1777,7 +1845,7 @@
 	)
 	(wire
 		(pts
-			(xy 261.62 57.15) (xy 266.7 57.15)
+			(xy 256.54 58.42) (xy 261.62 58.42)
 		)
 		(stroke
 			(width 0)
@@ -1827,6 +1895,16 @@
 	)
 	(wire
 		(pts
+			(xy 223.52 102.87) (xy 228.6 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d6fe564-7f72-47a9-bd6b-56e122911c7a")
+	)
+	(wire
+		(pts
 			(xy 24.13 50.8) (xy 44.45 50.8)
 		)
 		(stroke
@@ -1864,6 +1942,16 @@
 			(type default)
 		)
 		(uuid "447cee0c-7a66-4cbb-af13-0d0b437cd556")
+	)
+	(wire
+		(pts
+			(xy 228.6 82.55) (xy 228.6 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45f7a8d0-2145-4a10-8c5d-13ac6ea550bd")
 	)
 	(wire
 		(pts
@@ -1917,7 +2005,37 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 53.34) (xy 213.36 53.34)
+			(xy 209.55 71.12) (xy 209.55 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "51a5f6d9-04c5-45b4-b7c2-0d86b76342ff")
+	)
+	(wire
+		(pts
+			(xy 223.52 82.55) (xy 228.6 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52fc6a49-47e0-4052-adbd-72a42291f4ab")
+	)
+	(wire
+		(pts
+			(xy 208.28 68.58) (xy 208.28 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "54b5d19f-5927-4a39-ae7b-aca0728e5e99")
+	)
+	(wire
+		(pts
+			(xy 203.2 52.07) (xy 209.55 52.07)
 		)
 		(stroke
 			(width 0)
@@ -1987,7 +2105,17 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 68.58) (xy 213.36 68.58)
+			(xy 207.01 66.04) (xy 207.01 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "610cee3e-e41b-49fc-8522-e16349a90359")
+	)
+	(wire
+		(pts
+			(xy 203.2 67.31) (xy 207.01 67.31)
 		)
 		(stroke
 			(width 0)
@@ -2037,6 +2165,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 55.88) (xy 209.55 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c3ee61b-e1c7-4144-894c-c032658cb714")
+	)
+	(wire
+		(pts
 			(xy 44.45 50.8) (xy 64.77 50.8)
 		)
 		(stroke
@@ -2054,6 +2192,16 @@
 			(type default)
 		)
 		(uuid "6df5be49-20a4-4860-a8ae-c80e08f7f378")
+	)
+	(wire
+		(pts
+			(xy 231.14 80.01) (xy 231.14 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f483df5-6c6f-410c-ac2e-fb01ef99105f")
 	)
 	(wire
 		(pts
@@ -2147,6 +2295,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 58.42) (xy 208.28 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8391d239-450d-479d-8066-c6588e41179a")
+	)
+	(wire
+		(pts
 			(xy 156.21 124.46) (xy 156.21 144.78)
 		)
 		(stroke
@@ -2157,7 +2315,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 76.2) (xy 213.36 76.2)
+			(xy 203.2 74.93) (xy 209.55 74.93)
 		)
 		(stroke
 			(width 0)
@@ -2167,7 +2325,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 57.15) (xy 213.36 57.15)
+			(xy 203.2 55.88) (xy 208.28 55.88)
 		)
 		(stroke
 			(width 0)
@@ -2277,6 +2435,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 60.96) (xy 207.01 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a9ccc02-d776-4686-92d8-8b97374af150")
+	)
+	(wire
+		(pts
 			(xy 64.77 91.44) (xy 85.09 91.44)
 		)
 		(stroke
@@ -2304,6 +2472,16 @@
 			(type default)
 		)
 		(uuid "a1132f27-f21b-4a1c-b882-0bbce6458125")
+	)
+	(wire
+		(pts
+			(xy 213.36 68.58) (xy 208.28 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2973165-c071-486b-ae99-8247981025a2")
 	)
 	(wire
 		(pts
@@ -2347,7 +2525,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 72.39) (xy 213.36 72.39)
+			(xy 203.2 71.12) (xy 208.28 71.12)
 		)
 		(stroke
 			(width 0)
@@ -2427,6 +2605,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 71.12) (xy 209.55 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4eabdab-1bc2-4d71-a948-687da3e500b7")
+	)
+	(wire
+		(pts
 			(xy 135.89 83.82) (xy 135.89 104.14)
 		)
 		(stroke
@@ -2437,7 +2625,7 @@
 	)
 	(wire
 		(pts
-			(xy 261.62 76.2) (xy 265.43 76.2)
+			(xy 256.54 71.12) (xy 260.35 71.12)
 		)
 		(stroke
 			(width 0)
@@ -2464,6 +2652,16 @@
 			(type default)
 		)
 		(uuid "ca90b936-fbaf-4596-bcd1-4874943c35a2")
+	)
+	(wire
+		(pts
+			(xy 208.28 58.42) (xy 208.28 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc2e7aa0-f695-45c9-b1bb-bf0ad04f0cf9")
 	)
 	(wire
 		(pts
@@ -2494,6 +2692,16 @@
 			(type default)
 		)
 		(uuid "d5c07f37-0f5e-4527-b75c-402c376387ac")
+	)
+	(wire
+		(pts
+			(xy 228.6 105.41) (xy 228.6 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d84258a8-2463-4081-86e9-b4491e18150e")
 	)
 	(wire
 		(pts
@@ -2547,6 +2755,16 @@
 	)
 	(wire
 		(pts
+			(xy 207.01 60.96) (xy 207.01 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef626f01-ba75-409d-a400-09875a9043b2")
+	)
+	(wire
+		(pts
 			(xy 168.91 71.12) (xy 146.05 71.12)
 		)
 		(stroke
@@ -2557,7 +2775,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 64.77) (xy 213.36 64.77)
+			(xy 203.2 63.5) (xy 213.36 63.5)
 		)
 		(stroke
 			(width 0)
@@ -2629,7 +2847,7 @@
 	)
 	(global_label "IO 3"
 		(shape input)
-		(at 209.55 68.58 180)
+		(at 203.2 67.31 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2638,7 +2856,7 @@
 		)
 		(uuid "0bf63f66-d6f0-4aa9-bf55-372dcc9299b7")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 73.66 0)
+			(at 212.7711 72.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2672,7 +2890,7 @@
 	)
 	(global_label "INTR_L"
 		(shape input)
-		(at 209.55 53.34 180)
+		(at 203.2 52.07 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2681,7 +2899,7 @@
 		)
 		(uuid "2c302eeb-7435-4b36-955f-3edb0d42917a")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.0606 58.42 0)
+			(at 212.7106 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2715,7 +2933,7 @@
 	)
 	(global_label "IO 0"
 		(shape input)
-		(at 209.55 57.15 180)
+		(at 203.2 55.88 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2724,7 +2942,7 @@
 		)
 		(uuid "3ff55f05-b6f6-4332-ab3e-37346d8715f5")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 62.23 0)
+			(at 212.7711 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2736,7 +2954,7 @@
 	)
 	(global_label "IO 2"
 		(shape input)
-		(at 209.55 64.77 180)
+		(at 203.2 63.5 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2745,7 +2963,7 @@
 		)
 		(uuid "4a1b14bf-593d-4007-8519-99bcbcff3a70")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 69.85 0)
+			(at 212.7711 68.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2779,7 +2997,7 @@
 	)
 	(global_label "IO 4"
 		(shape input)
-		(at 209.55 72.39 180)
+		(at 203.2 71.12 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2788,7 +3006,7 @@
 		)
 		(uuid "64128e97-d339-4490-acbd-de4b452c705e")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 77.47 0)
+			(at 212.7711 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2800,7 +3018,7 @@
 	)
 	(global_label "IO 1"
 		(shape input)
-		(at 209.55 60.96 180)
+		(at 203.2 59.69 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2809,7 +3027,7 @@
 		)
 		(uuid "669f8b74-9a3b-48eb-a24f-a945334b796e")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 66.04 0)
+			(at 212.7711 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2843,7 +3061,7 @@
 	)
 	(global_label "IO 6"
 		(shape input)
-		(at 265.43 76.2 0)
+		(at 260.35 71.12 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -2853,12 +3071,56 @@
 		)
 		(uuid "79058bbe-0eb0-4f6c-97c6-eb02c1d50b6b")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 273.6389 76.2 0)
+			(at 268.5589 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BAT+"
+		(shape input)
+		(at 223.52 82.55 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8a7a3099-b347-4774-b061-7d04fc338de0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 215.6362 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BAT+"
+		(shape input)
+		(at 223.52 102.87 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "941f2717-ed8d-4553-a9d0-b13bc1d95129")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 215.6362 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
 				(hide yes)
 			)
 		)
@@ -2931,7 +3193,7 @@
 	)
 	(global_label "IO 5"
 		(shape input)
-		(at 209.55 76.2 180)
+		(at 203.2 74.93 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -2940,7 +3202,7 @@
 		)
 		(uuid "e5d29d66-60f0-4c51-9ff7-552d54635538")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 219.1211 81.28 0)
+			(at 212.7711 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3867,7 +4129,7 @@
 	(symbol
 		(lib_name "GND_2")
 		(lib_id "power:GND")
-		(at 266.7 57.15 0)
+		(at 261.62 58.42 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3876,7 +4138,7 @@
 		(fields_autoplaced yes)
 		(uuid "1dd61545-6fdf-421e-a667-8cdb70301608")
 		(property "Reference" "#PWR09"
-			(at 266.7 63.5 0)
+			(at 261.62 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3885,7 +4147,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 266.7 62.23 0)
+			(at 261.62 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3893,7 +4155,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3902,7 +4164,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3911,7 +4173,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4625,6 +4887,72 @@
 			(project "Assemble_L"
 				(path "/e3283b87-c43c-4022-8f4a-8d39acdeb3e4"
 					(reference "D4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 231.14 85.09 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3cfa0f20-4bc5-47ef-b6a8-fbc84ae481c2")
+		(property "Reference" "#PWR02"
+			(at 231.14 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 231.14 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad278e51-a6da-4ae7-ac50-99111b90dba9")
+		)
+		(instances
+			(project "Assemble_L"
+				(path "/e3283b87-c43c-4022-8f4a-8d39acdeb3e4"
+					(reference "#PWR02")
 					(unit 1)
 				)
 			)
@@ -5388,8 +5716,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Seeed_Studio_XIAO_Series:XIAO-nRF52840-DIP")
-		(at 219.71 49.53 0)
+		(lib_id "mcu:xiao-ble")
+		(at 234.95 63.5 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5398,23 +5726,25 @@
 		(fields_autoplaced yes)
 		(uuid "4e179371-2391-426b-ba45-e5b49bb84f48")
 		(property "Reference" "U1"
-			(at 237.49 45.72 0)
+			(at 238.3633 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Value" "XIAO-nRF52840"
-			(at 237.49 48.26 0)
+			(at 238.3633 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
-		(property "Footprint" "Seeed Studio XIAO Series Library:XIAO-nRF52840-DIP"
-			(at 232.41 80.264 0)
+		(property "Footprint" "mcu:xiao-ble-smd-cutout"
+			(at 227.33 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5423,7 +5753,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 215.9 46.99 0)
+			(at 227.33 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5432,7 +5762,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 215.9 46.99 0)
+			(at 234.95 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5481,6 +5811,30 @@
 		)
 		(pin "14"
 			(uuid "bf0f87d4-cadc-426f-bec3-9376ddebc65d")
+		)
+		(pin "15"
+			(uuid "e4f0eaa0-a8db-47f9-8d91-a77e54623aac")
+		)
+		(pin "22"
+			(uuid "fb1d4eec-0772-4cd0-a7ed-044481a6e418")
+		)
+		(pin "18"
+			(uuid "7f6204e7-e2ca-474f-bb56-005352e6733e")
+		)
+		(pin "16"
+			(uuid "bf8005ca-3b5f-4d06-905b-7f4da4dd368e")
+		)
+		(pin "17"
+			(uuid "11d25692-7f10-4dda-a7fb-ea6bb57e3a73")
+		)
+		(pin "19"
+			(uuid "45b94986-26a1-4957-8504-fc3290a23f31")
+		)
+		(pin "21"
+			(uuid "97802283-6919-4c17-818f-29ab7602381d")
+		)
+		(pin "20"
+			(uuid "416c0cd2-a3b8-48f0-a345-8bf6b21808b0")
 		)
 		(instances
 			(project ""
@@ -6502,6 +6856,72 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 228.6 110.49 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b587046-b49a-4e7c-befe-6ce266d44043")
+		(property "Reference" "#PWR03"
+			(at 228.6 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 228.6 115.57 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "634c0ab5-fc4a-476b-8313-94051d851c63")
+		)
+		(instances
+			(project "Assemble_L"
+				(path "/e3283b87-c43c-4022-8f4a-8d39acdeb3e4"
+					(reference "#PWR03")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Diode:1N4148")
 		(at 64.77 46.99 270)
 		(mirror x)
@@ -7229,6 +7649,76 @@
 			(project "Assemble_L"
 				(path "/e3283b87-c43c-4022-8f4a-8d39acdeb3e4"
 					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x02")
+		(at 233.68 102.87 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a270eb0c-4519-489a-88ec-70c8c4e783be")
+		(property "Reference" "J1"
+			(at 236.22 102.8699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x02"
+			(at 236.22 105.4099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_JST:JST_PH_B2B-PH-K_1x02_P2.00mm_Vertical"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "bf3100a9-b793-4aa6-aed9-a6a134757042")
+		)
+		(pin "1"
+			(uuid "6fa5f325-1927-4c40-9014-271cfa5e181c")
+		)
+		(instances
+			(project ""
+				(path "/e3283b87-c43c-4022-8f4a-8d39acdeb3e4"
+					(reference "J1")
 					(unit 1)
 				)
 			)

--- a/pcb_data/Assemble_L/fp-lib-table
+++ b/pcb_data/Assemble_L/fp-lib-table
@@ -4,4 +4,5 @@
   (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr ""))
   (lib (name "kbd_Parts")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/KiCAD_FootPrint/kbd_Parts")(options "")(descr ""))
   (lib (name "custom-library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/custom-library.pretty")(options "")(descr ""))
+  (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.pretty")(options "")(descr ""))
 )

--- a/pcb_data/Assemble_L/fp-lib-table
+++ b/pcb_data/Assemble_L/fp-lib-table
@@ -1,7 +1,7 @@
 (fp_lib_table
   (version 7)
-  (lib (name "Kailh_PG1353_Hotswap")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/MX_V2/Kailh_PG1353_Hotswap.pretty")(options "")(descr ""))
-  (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr ""))
+  (lib (name "Kailh_PG1353_Hotswap")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/MX_V2/Kailh_PG1353_Hotswap.pretty")(options "")(descr "")(disabled))
+  (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr "")(disabled))
   (lib (name "kbd_Parts")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/KiCAD_FootPrint/kbd_Parts")(options "")(descr ""))
   (lib (name "custom-library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/custom-library.pretty")(options "")(descr ""))
   (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.pretty")(options "")(descr ""))

--- a/pcb_data/Assemble_L/sym-lib-table
+++ b/pcb_data/Assemble_L/sym-lib-table
@@ -1,4 +1,5 @@
 (sym_lib_table
   (version 7)
   (lib (name "Seeed_Studio_XIAO_Series")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library/Seeed_Studio_XIAO_Series.kicad_sym")(options "")(descr ""))
+  (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.kicad_sym")(options "")(descr ""))
 )

--- a/pcb_data/Assemble_R/Assemble_R.kicad_sch
+++ b/pcb_data/Assemble_R/Assemble_R.kicad_sch
@@ -5,6 +5,148 @@
 	(uuid "38d74f02-042c-4f1b-a14f-ae40b0d0e57e")
 	(paper "A4")
 	(lib_symbols
+		(symbol "Connector_Generic:Conn_01x02"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x02"
+				(at 0 -5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x02_1_1"
+				(rectangle
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Diode:1N4148"
 			(pin_numbers
 				(hide yes)
@@ -273,609 +415,6 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Seeed_Studio_XIAO_Series:XIAO-nRF52840-DIP"
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "U"
-				(at -3.048 1.778 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "XIAO-nRF52840-DIP"
-				(at 3.048 -0.254 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" "Module:MOUDLE14P-XIAO-DIP-SMD"
-				(at 12.7 -30.734 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" ""
-				(at -3.81 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" ""
-				(at -3.81 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "XIAO-nRF52840-DIP_1_0"
-				(polyline
-					(pts
-						(xy -3.81 -1.27) (xy 39.37 -1.27)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -3.81) (xy -5.08 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -3.81) (xy -3.81 -1.27)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -7.62) (xy -5.08 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -7.62) (xy -3.81 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -11.43) (xy -5.08 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -11.43) (xy -3.81 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -15.24) (xy -5.08 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -15.24) (xy -3.81 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -19.05) (xy -5.08 -19.05)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -22.86) (xy -5.08 -22.86)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -26.67) (xy -5.08 -26.67)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.81 -29.21) (xy -3.81 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -1.27) (xy 39.37 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -3.81) (xy 39.37 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -7.62) (xy 39.37 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -11.43) (xy 39.37 -29.21)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 39.37 -29.21) (xy -3.81 -29.21)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -3.81) (xy 39.37 -3.81)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -7.62) (xy 39.37 -7.62)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -11.43) (xy 39.37 -11.43)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -15.24) (xy 39.37 -15.24)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -19.05) (xy 39.37 -19.05)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -22.86) (xy 39.37 -22.86)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 40.64 -26.67) (xy 39.37 -26.67)
-					)
-					(stroke
-						(width 0.1524)
-						(type solid)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(pin passive line
-					(at -6.35 -3.81 0)
-					(length 2.54)
-					(name "P0.02_AIN0_LOW_A0_D0"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -7.62 0)
-					(length 2.54)
-					(name "P0.03_AIN1_LOW_A1_D1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -11.43 0)
-					(length 2.54)
-					(name "P0.28_AIN4_LOW_A2_D2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -15.24 0)
-					(length 2.54)
-					(name "P0.29_AIN5_LOW_A3_D3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -19.05 0)
-					(length 2.54)
-					(name "P0.04_AIN2_A4_D4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -22.86 0)
-					(length 2.54)
-					(name "P0.05_AIN3_A5_D5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at -6.35 -26.67 0)
-					(length 2.54)
-					(name "P1.11_TX_D6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -3.81 180)
-					(length 2.54)
-					(name "VBUS"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -7.62 180)
-					(length 2.54)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "13"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -11.43 180)
-					(length 2.54)
-					(name "3V3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -15.24 180)
-					(length 2.54)
-					(name "P1.15_MOSI_D10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -19.05 180)
-					(length 2.54)
-					(name "P1.14_MISO_D9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -22.86 180)
-					(length 2.54)
-					(name "P1.13_SCK_D8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 41.91 -26.67 180)
-					(length 2.54)
-					(name "P1.12_RX_D7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "Switch:SW_Push"
 			(pin_numbers
 				(hide yes)
@@ -1016,6 +555,469 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "mcu:xiao-ble"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at -17.78 16.51 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "xiao-ble"
+				(at -15.24 13.97 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -7.62 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at -7.62 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "xiao-ble_0_1"
+				(rectangle
+					(start -19.05 12.7)
+					(end 19.05 -13.97)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "xiao-ble_1_1"
+				(pin bidirectional line
+					(at -21.59 7.62 0)
+					(length 2.54)
+					(name "A2/0.02_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 5.08 0)
+					(length 2.54)
+					(name "A4/0.03_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 2.54 0)
+					(length 2.54)
+					(name "A10/0.28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 0 0)
+					(length 2.54)
+					(name "A11/0.29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -2.54 0)
+					(length 2.54)
+					(name "A8_SDA/0.04_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -5.08 0)
+					(length 2.54)
+					(name "A9_SCL/0.05_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -7.62 0)
+					(length 2.54)
+					(name "B8_TX/1.11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -6.35 -16.51 90)
+					(length 2.54)
+					(name "BAT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -3.81 15.24 270)
+					(length 2.54)
+					(name "A31_SWDIO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -3.81 -16.51 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -1.27 15.24 270)
+					(length 2.54)
+					(name "A30_SWCLK"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -1.27 -16.51 90)
+					(length 2.54)
+					(name "NFC1/0.09_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 1.27 15.24 270)
+					(length 2.54)
+					(name "RESET"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 1.27 -16.51 90)
+					(length 2.54)
+					(name "NFC2/0.10_H"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 3.81 15.24 270)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 21.59 7.62 180)
+					(length 2.54)
+					(name "5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 21.59 5.08 180)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 21.59 2.54 180)
+					(length 2.54)
+					(name "3V3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 0 180)
+					(length 2.54)
+					(name "A6_MOSI/1.15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -2.54 180)
+					(length 2.54)
+					(name "A5_MISO/1.14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -5.08 180)
+					(length 2.54)
+					(name "A7_SCK/1.13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -7.62 180)
+					(length 2.54)
+					(name "B9_RX/1.12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1300,6 +1302,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "1670ad1a-d8e8-42d4-8f44-63d02f17616c")
+	)
+	(junction
+		(at 261.62 58.42)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1e498ac0-3dec-43e3-87d2-3f9a34418db7")
 	)
 	(junction
 		(at 105.41 91.44)
@@ -1734,23 +1742,43 @@
 		(uuid "f57dde1d-750a-422a-9581-29c688d87f39")
 	)
 	(no_connect
-		(at 261.62 72.39)
+		(at 256.54 68.58)
 		(uuid "012c8345-232a-46e6-b6cb-2b32d3a8cc56")
 	)
 	(no_connect
-		(at 261.62 68.58)
+		(at 236.22 48.26)
+		(uuid "0f521b9f-19f9-4a5f-ada1-a2ba6d857807")
+	)
+	(no_connect
+		(at 233.68 80.01)
+		(uuid "2600797e-cddc-4a59-8ff8-56e589871930")
+	)
+	(no_connect
+		(at 236.22 80.01)
+		(uuid "3d59acb7-32b9-4a64-9a72-e0ff696f12b8")
+	)
+	(no_connect
+		(at 256.54 66.04)
 		(uuid "68ae74f4-8cce-4e32-92a9-e9ce6f8a1ef2")
 	)
 	(no_connect
-		(at 261.62 64.77)
+		(at 231.14 48.26)
+		(uuid "97f24a2d-7777-4421-8181-bb41a56b1c71")
+	)
+	(no_connect
+		(at 256.54 63.5)
 		(uuid "a852128f-4fb6-4275-8a47-5d08ec039a47")
 	)
 	(no_connect
-		(at 261.62 60.96)
+		(at 256.54 60.96)
 		(uuid "c77bd407-6aaf-4f73-a757-0be98b4753c5")
 	)
 	(no_connect
-		(at 261.62 53.34)
+		(at 233.68 48.26)
+		(uuid "f6594459-63e5-4344-8255-736fc695396d")
+	)
+	(no_connect
+		(at 256.54 55.88)
 		(uuid "fc5fb51c-16d4-4daa-9137-042410ed1139")
 	)
 	(wire
@@ -1915,6 +1943,26 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 58.42) (xy 208.28 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17e0daef-8e60-49cf-a64f-277338438438")
+	)
+	(wire
+		(pts
+			(xy 213.36 71.12) (xy 209.55 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a50f6a0-0296-435a-bca6-c67752005a76")
+	)
+	(wire
+		(pts
 			(xy 156.21 104.14) (xy 156.21 124.46)
 		)
 		(stroke
@@ -1955,7 +2003,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 57.15) (xy 213.36 57.15)
+			(xy 203.2 55.88) (xy 208.28 55.88)
 		)
 		(stroke
 			(width 0)
@@ -1995,6 +2043,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 60.96) (xy 207.01 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d039404-5a18-44d5-910f-d045d03f9712")
+	)
+	(wire
+		(pts
 			(xy 54.61 43.18) (xy 54.61 63.5)
 		)
 		(stroke
@@ -2012,6 +2070,46 @@
 			(type default)
 		)
 		(uuid "2f4f783d-36ee-4478-87f3-b23b191ad4d7")
+	)
+	(wire
+		(pts
+			(xy 209.55 55.88) (xy 209.55 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "323378bd-4432-4171-a932-b7f486cf25e1")
+	)
+	(wire
+		(pts
+			(xy 261.62 48.26) (xy 261.62 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "32e69d30-3a7c-43db-853e-d4fd536893ba")
+	)
+	(wire
+		(pts
+			(xy 213.36 68.58) (xy 208.28 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34197cf2-84fb-4689-96bf-667623e0ad0a")
+	)
+	(wire
+		(pts
+			(xy 207.01 60.96) (xy 207.01 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34851e48-bf1f-4009-809c-f4f50891fa16")
 	)
 	(wire
 		(pts
@@ -2145,7 +2243,7 @@
 	)
 	(wire
 		(pts
-			(xy 261.62 57.15) (xy 266.7 57.15)
+			(xy 256.54 58.42) (xy 261.62 58.42)
 		)
 		(stroke
 			(width 0)
@@ -2195,6 +2293,16 @@
 	)
 	(wire
 		(pts
+			(xy 228.6 105.41) (xy 228.6 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "507d424f-2e70-4b89-bd7e-2606c27461f0")
+	)
+	(wire
+		(pts
 			(xy 156.21 27.94) (xy 156.21 63.5)
 		)
 		(stroke
@@ -2215,6 +2323,16 @@
 	)
 	(wire
 		(pts
+			(xy 228.6 82.55) (xy 228.6 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "555e77c5-e267-4cb5-beae-3df5b81c5321")
+	)
+	(wire
+		(pts
 			(xy 54.61 27.94) (xy 54.61 43.18)
 		)
 		(stroke
@@ -2225,7 +2343,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 53.34) (xy 213.36 53.34)
+			(xy 203.2 52.07) (xy 209.55 52.07)
 		)
 		(stroke
 			(width 0)
@@ -2355,7 +2473,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 68.58) (xy 213.36 68.58)
+			(xy 203.2 67.31) (xy 207.01 67.31)
 		)
 		(stroke
 			(width 0)
@@ -2372,6 +2490,16 @@
 			(type default)
 		)
 		(uuid "709106c7-3637-479a-95d0-196734677a1e")
+	)
+	(wire
+		(pts
+			(xy 207.01 66.04) (xy 207.01 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "72a8b538-b36f-4fbd-b6fd-cc5bff7e661c")
 	)
 	(wire
 		(pts
@@ -2412,6 +2540,16 @@
 			(type default)
 		)
 		(uuid "76df574b-a27a-4fed-ba38-245900e1b8ca")
+	)
+	(wire
+		(pts
+			(xy 223.52 82.55) (xy 228.6 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d3bf8be-24fc-413d-b8d5-177b847d83e4")
 	)
 	(wire
 		(pts
@@ -2465,7 +2603,7 @@
 	)
 	(wire
 		(pts
-			(xy 261.62 76.2) (xy 265.43 76.2)
+			(xy 256.54 71.12) (xy 260.35 71.12)
 		)
 		(stroke
 			(width 0)
@@ -2482,6 +2620,16 @@
 			(type default)
 		)
 		(uuid "8fbd85e9-78c1-481f-bb77-1f119d906762")
+	)
+	(wire
+		(pts
+			(xy 213.36 55.88) (xy 209.55 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "958d4543-de88-496a-8b0f-6c961637ca47")
 	)
 	(wire
 		(pts
@@ -2515,7 +2663,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 60.96) (xy 213.36 60.96)
+			(xy 203.2 59.69) (xy 207.01 59.69)
 		)
 		(stroke
 			(width 0)
@@ -2575,7 +2723,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 72.39) (xy 213.36 72.39)
+			(xy 203.2 71.12) (xy 208.28 71.12)
 		)
 		(stroke
 			(width 0)
@@ -2585,7 +2733,7 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 76.2) (xy 213.36 76.2)
+			(xy 203.2 74.93) (xy 209.55 74.93)
 		)
 		(stroke
 			(width 0)
@@ -2625,6 +2773,16 @@
 	)
 	(wire
 		(pts
+			(xy 238.76 48.26) (xy 261.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b92cc8f1-7dbf-4523-b843-5fa1af56ceed")
+	)
+	(wire
+		(pts
 			(xy 266.7 99.06) (xy 266.7 101.6)
 		)
 		(stroke
@@ -2645,7 +2803,17 @@
 	)
 	(wire
 		(pts
-			(xy 209.55 64.77) (xy 213.36 64.77)
+			(xy 208.28 68.58) (xy 208.28 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c307f74b-9ef3-4159-a3d1-bac9fd66480d")
+	)
+	(wire
+		(pts
+			(xy 203.2 63.5) (xy 213.36 63.5)
 		)
 		(stroke
 			(width 0)
@@ -2745,6 +2913,16 @@
 	)
 	(wire
 		(pts
+			(xy 213.36 66.04) (xy 207.01 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d28b1fea-c899-4563-80a6-a19661b63e65")
+	)
+	(wire
+		(pts
 			(xy 115.57 104.14) (xy 115.57 124.46)
 		)
 		(stroke
@@ -2772,6 +2950,26 @@
 			(type default)
 		)
 		(uuid "d896b8c0-3e53-455a-a965-4b280e49018d")
+	)
+	(wire
+		(pts
+			(xy 208.28 58.42) (xy 208.28 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8ba2e9b-71f4-4949-8134-bba683e64191")
+	)
+	(wire
+		(pts
+			(xy 209.55 71.12) (xy 209.55 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d931e636-b7d0-47ae-bd90-0f8575c56883")
 	)
 	(wire
 		(pts
@@ -2822,6 +3020,16 @@
 			(type default)
 		)
 		(uuid "e76c785c-8618-4697-99ed-ee4199139c50")
+	)
+	(wire
+		(pts
+			(xy 231.14 80.01) (xy 231.14 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7d1c0bf-8b7c-4e13-9f7a-b28319ffbf1b")
 	)
 	(wire
 		(pts
@@ -2913,9 +3121,19 @@
 		)
 		(uuid "f9fc5f5b-3745-447d-84db-d5ffd9dd98c4")
 	)
+	(wire
+		(pts
+			(xy 223.52 102.87) (xy 228.6 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa16e88c-5500-4894-a043-8ee6b1f2d229")
+	)
 	(global_label "INTR_R"
 		(shape input)
-		(at 209.55 53.34 180)
+		(at 203.2 52.07 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -2925,7 +3143,7 @@
 		)
 		(uuid "027fee85-f963-47d6-bedd-4b0ad2347559")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.2806 53.34 0)
+			(at 194.9306 52.07 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2981,7 +3199,7 @@
 	)
 	(global_label "IO 12"
 		(shape input)
-		(at 209.55 76.2 180)
+		(at 203.2 74.93 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -2991,7 +3209,7 @@
 		)
 		(uuid "31793166-8036-4247-810f-ca2e824b43c7")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 76.2 0)
+			(at 194.9911 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3025,7 +3243,7 @@
 	)
 	(global_label "IO 8"
 		(shape input)
-		(at 209.55 60.96 180)
+		(at 203.2 59.69 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3035,7 +3253,7 @@
 		)
 		(uuid "5273dd2c-741e-419c-8f80-f0b2e61a00f1")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 60.96 0)
+			(at 194.9911 59.69 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3069,7 +3287,7 @@
 	)
 	(global_label "IO 13"
 		(shape input)
-		(at 265.43 76.2 0)
+		(at 260.35 71.12 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3079,7 +3297,7 @@
 		)
 		(uuid "7c64db15-6674-4319-88b1-3cfdd2904c3d")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 273.6389 76.2 0)
+			(at 268.5589 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3091,7 +3309,7 @@
 	)
 	(global_label "IO 7"
 		(shape input)
-		(at 209.55 57.15 180)
+		(at 203.2 55.88 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3101,7 +3319,7 @@
 		)
 		(uuid "81283b98-cb8c-4c73-a871-58e22f842faf")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 57.15 0)
+			(at 194.9911 55.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3113,7 +3331,7 @@
 	)
 	(global_label "IO 11"
 		(shape input)
-		(at 209.55 72.39 180)
+		(at 203.2 71.12 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3123,7 +3341,7 @@
 		)
 		(uuid "81bf223b-64c3-4bae-9e31-2d472c13003a")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 72.39 0)
+			(at 194.9911 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3157,7 +3375,7 @@
 	)
 	(global_label "IO 9"
 		(shape input)
-		(at 209.55 64.77 180)
+		(at 203.2 63.5 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3167,7 +3385,7 @@
 		)
 		(uuid "aa1bc7c6-8e71-410b-9597-60bc053a9fc7")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 64.77 0)
+			(at 194.9911 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3190,6 +3408,50 @@
 		(uuid "b8367492-bab5-4d49-ba22-99077d1ce522")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
 			(at 74.93 19.8105 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BAT+"
+		(shape input)
+		(at 223.52 102.87 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c78768a2-9573-4145-ae34-d1e128b7b109")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 215.6362 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BAT+"
+		(shape input)
+		(at 223.52 82.55 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d33b36a3-6741-47f7-8d77-e7d5c6e8c4f5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 215.6362 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3223,7 +3485,7 @@
 	)
 	(global_label "IO 10"
 		(shape input)
-		(at 209.55 68.58 180)
+		(at 203.2 67.31 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -3233,7 +3495,7 @@
 		)
 		(uuid "fb1154e3-ba42-4dd6-8d96-b796ae3de90b")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 201.3411 68.58 0)
+			(at 194.9911 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3262,6 +3524,73 @@
 				)
 				(justify left)
 				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_2")
+		(lib_id "power:GND")
+		(at 231.14 85.09 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0384bf17-a7e9-4958-991d-e6e4186b1b9a")
+		(property "Reference" "#PWR02"
+			(at 231.14 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 231.14 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 231.14 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e56a584b-5bd0-4857-86c1-5c83453cbcbf")
+		)
+		(instances
+			(project "Assemble_R"
+				(path "/38d74f02-042c-4f1b-a14f-ae40b0d0e57e"
+					(reference "#PWR02")
+					(unit 1)
+				)
 			)
 		)
 	)
@@ -3339,7 +3668,7 @@
 	(symbol
 		(lib_name "GND_2")
 		(lib_id "power:GND")
-		(at 266.7 57.15 0)
+		(at 261.62 58.42 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3348,7 +3677,7 @@
 		(fields_autoplaced yes)
 		(uuid "0c540e57-7805-4323-96d2-c30bd2130e69")
 		(property "Reference" "#PWR010"
-			(at 266.7 63.5 0)
+			(at 261.62 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3357,7 +3686,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 266.7 62.23 0)
+			(at 261.62 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3365,7 +3694,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3374,7 +3703,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3383,7 +3712,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 266.7 57.15 0)
+			(at 261.62 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6538,6 +6867,73 @@
 		)
 	)
 	(symbol
+		(lib_name "GND_2")
+		(lib_id "power:GND")
+		(at 228.6 110.49 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "58726cb9-6c9a-4f21-a272-3148c60b9464")
+		(property "Reference" "#PWR03"
+			(at 228.6 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 228.6 115.57 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 228.6 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a62d7054-1f7a-4e2a-ab46-f21e39318101")
+		)
+		(instances
+			(project "Assemble_R"
+				(path "/38d74f02-042c-4f1b-a14f-ae40b0d0e57e"
+					(reference "#PWR03")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Switch:SW_Push")
 		(at 130.81 124.46 0)
 		(mirror y)
@@ -8032,6 +8428,76 @@
 		)
 	)
 	(symbol
+		(lib_id "Connector_Generic:Conn_01x02")
+		(at 233.68 102.87 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "91214cf4-b50d-4c53-8ea4-0b0273e7b301")
+		(property "Reference" "J1"
+			(at 236.22 102.8699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x02"
+			(at 236.22 105.4099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_JST:JST_PH_B2B-PH-K_1x02_P2.00mm_Vertical"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 233.68 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "52964341-0830-4eb3-8629-3f1ab8d8e4cd")
+		)
+		(pin "1"
+			(uuid "76f888e9-41db-4e0b-b05e-c125415ea4a3")
+		)
+		(instances
+			(project ""
+				(path "/38d74f02-042c-4f1b-a14f-ae40b0d0e57e"
+					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Diode:1N4148")
 		(at 64.77 87.63 90)
 		(mirror x)
@@ -8214,8 +8680,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Seeed_Studio_XIAO_Series:XIAO-nRF52840-DIP")
-		(at 219.71 49.53 0)
+		(lib_id "mcu:xiao-ble")
+		(at 234.95 63.5 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8224,23 +8690,25 @@
 		(fields_autoplaced yes)
 		(uuid "9f95cae5-14c5-49b9-bafb-b9bd35929f87")
 		(property "Reference" "U1"
-			(at 237.49 45.72 0)
+			(at 238.3633 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Value" "XIAO-nRF52840"
-			(at 237.49 48.26 0)
+			(at 238.3633 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
-		(property "Footprint" "Seeed Studio XIAO Series Library:XIAO-nRF52840-DIP"
-			(at 232.41 80.264 0)
+		(property "Footprint" "mcu:xiao-ble-smd-cutout"
+			(at 227.33 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8249,7 +8717,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 215.9 46.99 0)
+			(at 227.33 58.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8258,7 +8726,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 215.9 46.99 0)
+			(at 234.95 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8307,6 +8775,30 @@
 		)
 		(pin "8"
 			(uuid "7eaafb86-f7bf-44a3-ac47-4a34d79aa098")
+		)
+		(pin "22"
+			(uuid "ba484b4e-fcf5-4cb8-935e-74615fdd390d")
+		)
+		(pin "15"
+			(uuid "39b23cef-268f-40b4-a62a-318390adffb2")
+		)
+		(pin "20"
+			(uuid "39bcf652-301c-485f-9159-f9a37e69a4d8")
+		)
+		(pin "19"
+			(uuid "4e4d379e-ceea-4b8c-84f5-2bc6b9015403")
+		)
+		(pin "21"
+			(uuid "d3e8e978-5972-45d1-8a91-e967690a4ed2")
+		)
+		(pin "18"
+			(uuid "2604b9c0-3ac9-4522-8de2-c61374f4de4e")
+		)
+		(pin "16"
+			(uuid "38c56604-f829-44a3-b371-8055e0de4881")
+		)
+		(pin "17"
+			(uuid "0cf885fc-9331-4abe-adb5-c34ff3f33dab")
 		)
 		(instances
 			(project ""

--- a/pcb_data/Assemble_R/fp-lib-table
+++ b/pcb_data/Assemble_R/fp-lib-table
@@ -4,4 +4,5 @@
   (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr ""))
   (lib (name "kbd_Parts")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/KiCAD_FootPrint/kbd_Parts")(options "")(descr ""))
   (lib (name "custom-library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/custom-library.pretty")(options "")(descr ""))
+  (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.pretty")(options "")(descr ""))
 )

--- a/pcb_data/Assemble_R/fp-lib-table
+++ b/pcb_data/Assemble_R/fp-lib-table
@@ -1,7 +1,7 @@
 (fp_lib_table
   (version 7)
-  (lib (name "Kailh_PG1353_Hotswap")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/MX_V2/Kailh_PG1353_Hotswap.pretty")(options "")(descr ""))
-  (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr ""))
+  (lib (name "Kailh_PG1353_Hotswap")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/MX_V2/Kailh_PG1353_Hotswap.pretty")(options "")(descr "")(disabled))
+  (lib (name "Seeed Studio XIAO Series Library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library")(options "")(descr "")(disabled))
   (lib (name "kbd_Parts")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/KiCAD_FootPrint/kbd_Parts")(options "")(descr ""))
   (lib (name "custom-library")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/custom-library.pretty")(options "")(descr ""))
   (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.pretty")(options "")(descr ""))

--- a/pcb_data/Assemble_R/sym-lib-table
+++ b/pcb_data/Assemble_R/sym-lib-table
@@ -1,4 +1,5 @@
 (sym_lib_table
   (version 7)
   (lib (name "Seeed_Studio_XIAO_Series")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/OPL_Kicad_Library/Seeed Studio XIAO Series Library/Seeed_Studio_XIAO_Series.kicad_sym")(options "")(descr ""))
+  (lib (name "mcu")(type "KiCad")(uri "${KIPRJMOD}/../kicad_library/external/kleeb/mcu.kicad_sym")(options "")(descr ""))
 )


### PR DESCRIPTION
Closes #11 

- kleeb をサブモジュールとして追加
  - xiao nRF52840のシンボルのGNDの修正
- 別ブランチで行われていたサブモジュールのURL変更を取り込み
- 現在未使用のフットプリントライブラリを非アクティブ化（暫定対応）
- 回路図内のxiao nRF52840のシンボルの更新
  - 背面BATパッド対応のSMD版フットプリントを紐づけ

回路図は左右共にERC通っています。